### PR TITLE
added ctrl + j shortcut functionality on macs

### DIFF
--- a/html/quickjump4ward.js
+++ b/html/quickjump4ward.js
@@ -185,7 +185,7 @@ var Quickjump4ward = new Class({
 	 * Hotkey to jump into the autocompleter field
 	 */
 	keypress: function(e){
-		if((e.code == 106 || e.code == 74 || e.code == 17) && e.control) {
+		if((e.code == 106 || e.code == 74 || e.code == 17 || e.code == 10) && e.control) {
 			e.preventDefault();
 			this.input.focus();
 		}


### PR DESCRIPTION
on macs, the ctrl + j shortcut was not working with chrome, safari and opera. firefox was able to deal with it. I added the e.code == 10 to support the other browsers.
